### PR TITLE
Optimize portfolio image delivery

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,5 +7,8 @@ export default defineConfig({
   integrations: [
     tailwind(),
     react() // Añade React a la lista de integraciones
-  ]
+  ],
+  image: {
+    domains: ["opengraph.githubassets.com"],
+  }
 });

--- a/src/components/Proyects.astro
+++ b/src/components/Proyects.astro
@@ -2,6 +2,7 @@
 import DesktopIcon from "../icons/DesktopIcon.astro";
 import GitHubIcon from "../icons/GitHubIcon.astro";
 import SocialPill from "./SocialPill.astro";
+import { Image } from "astro:assets";
 const GITHUB_TOKEN = import.meta.env.GITHUB_TOKEN;
 const GITHUB_URL = import.meta.env.GITHUB_URL;
 interface Proyect {
@@ -285,9 +286,13 @@ try {
                                                 </p>
                                             </div>
                                         )}
-                                        <img
+                                        <Image
                                             src={image}
                                             alt={title}
+                                            width={384}
+                                            height={192}
+                                            format="webp"
+                                            loading="lazy"
                                             class="mb-4 rounded-lg w-full h-48 object-cover"
                                         />
                                     </a>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -29,11 +29,13 @@ import myPhoto from "/public/photo.webp";
 		<div
 			class="flex flex-col items-center sm:items-start sm:flex-row sm:gap-x-4"
 		>
-			<Image
-				class="rounded-full size-24 sm:size-32 object-cover object-center mb-4 sm:mb-0 lg:mb-4 border-4 border-gray-200 dark:border-gray-800"
-				src={myPhoto}
-				alt="Mikel Echeverria, Desarrollador Full Stack y Backend"
-			/>
+                        <Image
+                                class="rounded-full size-24 sm:size-32 object-cover object-center mb-4 sm:mb-0 lg:mb-4 border-4 border-gray-200 dark:border-gray-800"
+                                src={myPhoto}
+                                alt="Mikel Echeverria, Desarrollador Full Stack y Backend"
+                                width={128}
+                                height={128}
+                        />
 			<div
 				class="flex flex-col lg:flex-row gap-x-4 items-center sm:items-start"
 			>


### PR DESCRIPTION
## Summary
- resize profile photo with explicit dimensions
- load project thumbnails through Astro's Image component and lazy loading
- allow image optimization for GitHub OpenGraph domains

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895a478bfc4832c9e16b6189e7b4e83