### PR TITLE
Add downloadable multilingual CV

### DIFF
--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -8,6 +8,9 @@
   "badge": {
     "available": "Verfügbar für neue Projekte"
   },
+  "cv": {
+    "download": "Lebenslauf herunterladen"
+  },
   "hero": {
     "hello": "Hallo! Ich bin",
     "description": "Backend- und Full-Stack-Entwickler mit Sitz in Pamplona, Spanien 🇪🇸. Begeistert von Technologie, Innovation und Design und engagiert, außergewöhnliche Erlebnisse und kreative Lösungen zu schaffen."

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -8,6 +8,9 @@
   "badge": {
     "available": "Available for work"
   },
+  "cv": {
+    "download": "Download CV"
+  },
   "hero": {
     "hello": "Hi! I'm",
     "description": "Backend and full-stack developer based in Pamplona, Spain 🇪🇸. Passionate about technology, innovation and design, committed to creating outstanding experiences and creative solutions."

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -8,6 +8,9 @@
   "badge": {
     "available": "Disponible para trabajar"
   },
+  "cv": {
+    "download": "Descargar currículum"
+  },
   "hero": {
     "hello": "¡Hola! Soy",
     "description": "Desarrollador Backend y Full Stack en Pamplona, España 🇪🇸. Apasionado por la tecnología, la innovación y el diseño. Comprometido con la creación de experiencias excepcionales y soluciones creativas."

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -8,6 +8,9 @@
   "badge": {
     "available": "Disponible pour travailler"
   },
+  "cv": {
+    "download": "Télécharger le CV"
+  },
   "hero": {
     "hello": "Bonjour ! Je suis",
     "description": "Développeur backend et full-stack basé à Pampelune, Espagne 🇪🇸. Passionné de technologie, d'innovation et de design, engagé à créer des expériences exceptionnelles et des solutions créatives."

--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -8,6 +8,9 @@
   "badge": {
     "available": "Disponibile a lavorare"
   },
+  "cv": {
+    "download": "Scarica il CV"
+  },
   "hero": {
     "hello": "Ciao! Sono",
     "description": "Sviluppatore backend e full-stack con sede a Pamplona, Spagna 🇪🇸. Appassionato di tecnologia, innovazione e design, impegnato a creare esperienze eccezionali e soluzioni creative."

--- a/public/scripts/cv.js
+++ b/public/scripts/cv.js
@@ -1,0 +1,68 @@
+(async function () {
+  const { jsPDF } = window.jspdf || {};
+  if (!jsPDF) return;
+
+  async function loadImageAsPng(url) {
+    const blob = await fetch(url).then((r) => r.blob());
+    return await new Promise((resolve) => {
+      const img = new Image();
+      img.onload = () => {
+        const canvas = document.createElement('canvas');
+        canvas.width = img.width;
+        canvas.height = img.height;
+        const ctx = canvas.getContext('2d');
+        ctx.drawImage(img, 0, 0);
+        resolve(canvas.toDataURL('image/png'));
+      };
+      img.src = URL.createObjectURL(blob);
+    });
+  }
+
+  function stripHtml(html) {
+    const tmp = document.createElement('div');
+    tmp.innerHTML = html;
+    return tmp.textContent || tmp.innerText || '';
+  }
+
+  async function generateCV() {
+    const lang = localStorage.getItem('lang') || 'en';
+    const res = await fetch(`/locales/${lang}.json`);
+    const t = await res.json();
+
+    const doc = new jsPDF();
+    const imgData = await loadImageAsPng('/photo.webp');
+
+    doc.addImage(imgData, 'PNG', 15, 15, 30, 30);
+    doc.setFontSize(16);
+    doc.text('Mikel Echeverria', 50, 25);
+    doc.setFontSize(12);
+    doc.text('mikel@mikeldev.com', 50, 32);
+
+    doc.setFontSize(12);
+    doc.text(stripHtml(t.hero.description), 15, 55, { maxWidth: 180 });
+
+    doc.setFontSize(14);
+    doc.text(t.section.experience, 15, 75);
+    doc.setFontSize(12);
+
+    const order = ['codetec', 'tesicnor_backend', 'camp', 'tesicnor_intern', 'burlada'];
+    let y = 85;
+    order.forEach((key) => {
+      const exp = t.experience[key];
+      if (!exp) return;
+      doc.text(`${exp.date} - ${exp.title}`, 15, y, { maxWidth: 180 });
+      y += 6;
+      doc.text(stripHtml(exp.description), 15, y, { maxWidth: 180 });
+      y += 10;
+    });
+
+    doc.save(`cv-${lang}.pdf`);
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const btn = document.getElementById('download-cv');
+    if (btn) {
+      btn.addEventListener('click', generateCV);
+    }
+  });
+})();

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -100,6 +100,8 @@ const { description, title } = Astro.props;
                 <Header />
                 <slot />
                 <script src="/i18n.js" is:inline></script>
+                <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+                <script src="/scripts/cv.js" is:inline></script>
         </body>
 </html>
 <style is:global>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -68,43 +68,51 @@ import myPhoto from "/public/photo.webp";
                         <span data-i18n="hero.description" class="text-gray-900 dark:text-gray-100 opacity-80">Desarrollador Backend y Full Stack en Pamplona, España 🇪🇸. Apasionado por la tecnología, innovación y el diseño. Comprometido en crear experiencias excepcionales y soluciones creativas.</span>
                 </h2>
 
-		<ul class="flex flex-wrap justify-center sm:justify-start gap-4 mt-8">
-			<li>
-				<SocialPill
-					perfilPill
-					href="https://github.mikeldev.com"
-					title="Perfil de Github de Mikel Echeverria"
-				>
-					<GitHubIcon class="size-5 sm:size-6" />
-				</SocialPill>
-			</li>
-			<li>
-				<SocialPill
-					href="https://www.linkedin.com/in/mikel-echeverria"
-					title="Perfil de LinkedIn de Mikel Echeverria"
-				>
-					<LinkedInIcon class="size-5 sm:size-6" />
-				</SocialPill>
-			</li>
-			<li>
-				<SocialPill
-					href="https://x.com/MikelEcheve"
-					title="Perfil de X de Mikel Echeverria"
-				>
-					<XIcon class="size-5 sm:size-6" />
-				</SocialPill>
-			</li>
-			<li>
-				<SocialPill
-					href="mailto:mikel@mikeldev.com"
-					title="Enviar correo a Mikel Echeverria"
-				>
-					<MailIcon class="size-5 sm:size-6" />
-					<span class="text-gray-800 dark:text-gray-200">mikel@mikeldev.com</span>
-				</SocialPill>
-			</li>
-		</ul>
-	</SectionContainer>
+                <ul class="flex flex-wrap justify-center sm:justify-start gap-4 mt-8">
+                        <li>
+                                <SocialPill
+                                        perfilPill
+                                        href="https://github.mikeldev.com"
+                                        title="Perfil de Github de Mikel Echeverria"
+                                >
+                                        <GitHubIcon class="size-5 sm:size-6" />
+                                </SocialPill>
+                        </li>
+                        <li>
+                                <SocialPill
+                                        href="https://www.linkedin.com/in/mikel-echeverria"
+                                        title="Perfil de LinkedIn de Mikel Echeverria"
+                                >
+                                        <LinkedInIcon class="size-5 sm:size-6" />
+                                </SocialPill>
+                        </li>
+                        <li>
+                                <SocialPill
+                                        href="https://x.com/MikelEcheve"
+                                        title="Perfil de X de Mikel Echeverria"
+                                >
+                                        <XIcon class="size-5 sm:size-6" />
+                                </SocialPill>
+                        </li>
+                        <li>
+                                <SocialPill
+                                        href="mailto:mikel@mikeldev.com"
+                                        title="Enviar correo a Mikel Echeverria"
+                                >
+                                        <MailIcon class="size-5 sm:size-6" />
+                                        <span class="text-gray-800 dark:text-gray-200">mikel@mikeldev.com</span>
+                                </SocialPill>
+                        </li>
+                </ul>
+
+                <button
+                        id="download-cv"
+                        class="mt-8 px-4 py-2 border border-gray-700 dark:border-gray-300 rounded text-gray-900 dark:text-gray-100 hover:bg-gray-200 dark:hover:bg-gray-800"
+                        data-i18n="cv.download"
+                >
+                        Descargar currículum
+                </button>
+        </SectionContainer>
 
 	<SectionContainer class="py-16 sm:py-32 text-gray-900 dark:text-gray-100">
                 <h2 id="experiencia" class="text-2xl font-bold mb-6 flex gap-x-2 " data-i18n="section.experience">


### PR DESCRIPTION
## Summary
- add "Download CV" translations and button on homepage
- load jsPDF and custom script to generate language-specific CV PDF
- generate resume PDF with photo and experience using selected locale

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68973fc97650832c939f61451ec9f8f7