### PR TITLE
Add holiday hat overlay for profile image

### DIFF
--- a/src/components/HolidayProfileImage.tsx
+++ b/src/components/HolidayProfileImage.tsx
@@ -20,7 +20,7 @@ export default function HolidayProfileImage({ className }: Props) {
                         {showHolidayHat && (
                                 <img
                                         aria-hidden="true"
-                                        className="absolute -top-6 left-4 sm:-top-8 sm:left-6 lg:-top-7 lg:left-8 rotate-[-15deg] w-20 sm:w-24 drop-shadow-md"
+                                        className="absolute -top-6 right-6 sm:-top-8 sm:left-6 lg:-top-7 lg:left-8 rotate-[-15deg] w-20 sm:w-24 drop-shadow-md"
                                         src="/TheresaKnott_Santa_Hat.svg"
                                         alt=""
                                 />

--- a/src/components/HolidayProfileImage.tsx
+++ b/src/components/HolidayProfileImage.tsx
@@ -1,0 +1,30 @@
+import { useHolidayEffectsActive } from "../lib/holiday";
+
+interface Props {
+        className?: string;
+}
+
+export default function HolidayProfileImage({ className }: Props) {
+        const showHolidayHat = useHolidayEffectsActive();
+
+        return (
+                <div className={["relative", className].filter(Boolean).join(" ")}>
+                        <img
+                                className="rounded-full size-24 sm:size-32 object-cover object-center border-4 border-gray-200 dark:border-gray-800"
+                                src="/photo.webp"
+                                alt="Mikel Echeverria, Desarrollador Full Stack y Backend"
+                                width={128}
+                                height={128}
+                                loading="eager"
+                        />
+                        {showHolidayHat && (
+                                <img
+                                        aria-hidden="true"
+                                        className="absolute -top-6 left-4 sm:-top-7 sm:left-5 lg:-top-6 lg:left-4 rotate-[-18deg] w-20 sm:w-24 drop-shadow-md"
+                                        src="/TheresaKnott_Santa_Hat.svg"
+                                        alt=""
+                                />
+                        )}
+                </div>
+        );
+}

--- a/src/components/HolidayProfileImage.tsx
+++ b/src/components/HolidayProfileImage.tsx
@@ -20,7 +20,7 @@ export default function HolidayProfileImage({ className }: Props) {
                         {showHolidayHat && (
                                 <img
                                         aria-hidden="true"
-                                        className="absolute -top-6 right-6 sm:-top-8 sm:left-6 lg:-top-7 lg:left-8 rotate-[-15deg] w-20 sm:w-24 drop-shadow-md"
+                                        className="absolute -top-6 right-6 sm:-top-8 sm:right-6 lg:-top-7 lg:right-8 rotate-[-15deg] w-20 sm:w-24 drop-shadow-md"
                                         src="/TheresaKnott_Santa_Hat.svg"
                                         alt=""
                                 />

--- a/src/components/HolidayProfileImage.tsx
+++ b/src/components/HolidayProfileImage.tsx
@@ -20,7 +20,7 @@ export default function HolidayProfileImage({ className }: Props) {
                         {showHolidayHat && (
                                 <img
                                         aria-hidden="true"
-                                        className="absolute -top-6 left-4 sm:-top-7 sm:left-5 lg:-top-6 lg:left-4 rotate-[-18deg] w-20 sm:w-24 drop-shadow-md"
+                                        className="absolute -top-10 left-1/2 -translate-x-1/2 sm:-top-12 sm:-translate-x-1/2 lg:-top-11 rotate-[-15deg] w-20 sm:w-24 drop-shadow-md"
                                         src="/TheresaKnott_Santa_Hat.svg"
                                         alt=""
                                 />

--- a/src/components/HolidayProfileImage.tsx
+++ b/src/components/HolidayProfileImage.tsx
@@ -20,7 +20,7 @@ export default function HolidayProfileImage({ className }: Props) {
                         {showHolidayHat && (
                                 <img
                                         aria-hidden="true"
-                                        className="absolute -top-10 left-1/2 -translate-x-1/2 sm:-top-12 sm:-translate-x-1/2 lg:-top-11 rotate-[-15deg] w-20 sm:w-24 drop-shadow-md"
+                                        className="absolute -top-6 left-4 sm:-top-8 sm:left-6 lg:-top-7 lg:left-8 rotate-[-15deg] w-20 sm:w-24 drop-shadow-md"
                                         src="/TheresaKnott_Santa_Hat.svg"
                                         alt=""
                                 />

--- a/src/components/HolidayProfileImage.tsx
+++ b/src/components/HolidayProfileImage.tsx
@@ -20,7 +20,7 @@ export default function HolidayProfileImage({ className }: Props) {
                         {showHolidayHat && (
                                 <img
                                         aria-hidden="true"
-                                        className="absolute -top-6 right-6 sm:-top-8 sm:right-6 lg:-top-7 lg:right-8 rotate-[-15deg] w-20 sm:w-24 drop-shadow-md"
+                                        className="absolute -top-6 right-10 sm:-top-8 sm:right-12 lg:-top-7 lg:right-14 rotate-[-15deg] w-20 sm:w-24 drop-shadow-md"
                                         src="/TheresaKnott_Santa_Hat.svg"
                                         alt=""
                                 />

--- a/src/components/Snowfall.tsx
+++ b/src/components/Snowfall.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef, useState } from "react";
-import { env } from "../lib/env";
+import { useEffect, useRef } from "react";
+import { useHolidayEffectsActive } from "../lib/holiday";
 
 interface Snowflake {
         x: number;
@@ -10,35 +10,10 @@ interface Snowflake {
 }
 
 const SNOWFLAKE_COUNT = 120;
-const HOLIDAY_END_DAY = 7;
-
-const isWithinHolidaySeason = (date: Date) => {
-        const month = date.getMonth();
-        const day = date.getDate();
-
-        return month === 11 || (month === 0 && day <= HOLIDAY_END_DAY);
-};
-
 export default function Snowfall() {
         const canvasRef = useRef<HTMLCanvasElement>(null);
         const animationRef = useRef<number>();
-        const [isActive, setIsActive] = useState(false);
-        const { enableHolidayEffects } = env;
-
-        useEffect(() => {
-                const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
-                const updateSeasonalState = () => {
-                        const holidayActive = isWithinHolidaySeason(new Date());
-                        setIsActive(enableHolidayEffects && holidayActive && !prefersReducedMotion.matches);
-                };
-
-                updateSeasonalState();
-                prefersReducedMotion.addEventListener("change", updateSeasonalState);
-
-                return () => {
-                        prefersReducedMotion.removeEventListener("change", updateSeasonalState);
-                };
-        }, [enableHolidayEffects]);
+        const isActive = useHolidayEffectsActive();
 
         useEffect(() => {
                 if (!isActive) return;
@@ -111,7 +86,7 @@ export default function Snowfall() {
                 };
         }, [isActive]);
 
-        if (!enableHolidayEffects || !isActive) {
+        if (!isActive) {
                 return null;
         }
 

--- a/src/lib/holiday.ts
+++ b/src/lib/holiday.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+import { env } from "./env";
+
+const HOLIDAY_END_DAY = 7;
+
+export const isWithinHolidaySeason = (date: Date) => {
+        const month = date.getMonth();
+        const day = date.getDate();
+
+        return month === 11 || (month === 0 && day <= HOLIDAY_END_DAY);
+};
+
+export const useHolidayEffectsActive = () => {
+        const [isActive, setIsActive] = useState(false);
+        const { enableHolidayEffects } = env;
+
+        useEffect(() => {
+                const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+
+                const updateSeasonalState = () => {
+                        const holidayActive = isWithinHolidaySeason(new Date());
+                        setIsActive(enableHolidayEffects && holidayActive && !prefersReducedMotion.matches);
+                };
+
+                updateSeasonalState();
+                prefersReducedMotion.addEventListener("change", updateSeasonalState);
+
+                return () => {
+                        prefersReducedMotion.removeEventListener("change", updateSeasonalState);
+                };
+        }, [enableHolidayEffects]);
+
+        return isActive;
+};

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,8 +1,8 @@
 ---
-import { Image } from "astro:assets";
 import AboutMe from "../components/AboutMe.astro";
 import Badge from "../components/Badge.astro";
 import Experiences from "../components/Experiences.astro";
+import HolidayProfileImage from "../components/HolidayProfileImage";
 import Footer from "../components/Footer.astro";
 import ProfileCheck from "../components/ProfileCheck.astro";
 import Proyects from "../components/Proyects.astro";
@@ -17,7 +17,6 @@ import LinkedInIcon from "../icons/LinkedInIcon.astro";
 import MailIcon from "../icons/MailIcon.astro";
 import XIcon from "../icons/XIcon.astro";
 import Layout from "../layouts/Layout.astro";
-import myPhoto from "/public/photo.webp";
 ---
 
 <Layout
@@ -29,13 +28,7 @@ import myPhoto from "/public/photo.webp";
 		<div
 			class="flex flex-col items-center sm:items-start sm:flex-row sm:gap-x-4"
 		>
-                        <Image
-                                class="rounded-full size-24 sm:size-32 object-cover object-center mb-4 sm:mb-0 lg:mb-4 border-4 border-gray-200 dark:border-gray-800"
-                                src={myPhoto}
-                                alt="Mikel Echeverria, Desarrollador Full Stack y Backend"
-                                width={128}
-                                height={128}
-                        />
+                        <HolidayProfileImage className="mb-4 sm:mb-0 lg:mb-4" client:load />
 			<div
 				class="flex flex-col lg:flex-row gap-x-4 items-center sm:items-start"
 			>


### PR DESCRIPTION
## Summary
- add shared holiday effect hook to reuse seasonal activation logic
- show a festive santa hat over the profile photo while holiday effects are active
- reuse the shared hook in the snowfall effect to centralize holiday toggling

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6949f443441c8322b2d626691abd4291)